### PR TITLE
bitbots_move_base: Fix model launch param

### DIFF
--- a/bitbots_move_base/launch/pathfinding_move_base.launch
+++ b/bitbots_move_base/launch/pathfinding_move_base.launch
@@ -11,7 +11,7 @@
 
   <group unless="$(arg localization)">
     <node name="tf_odom_to_map" pkg="bitbots_move_base" type="tf_map_odom.py" output="screen"/>
-    <node name="map_server" pkg="map_server" type="map_server" output="screen" args="$(find bitbots_localization)/models/germanopen2019.yaml"/>
+    <node name="map_server" pkg="map_server" type="map_server" output="screen" args="$(find bitbots_localization)/models/field2019.yaml"/>
   </group>
 
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/bitbots_move_base/package.xml
+++ b/bitbots_move_base/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_move_base</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>The bitbots_move_base package contains config files and launch scripts for move_base which does planning
   and plan execution</description>
 


### PR DESCRIPTION
## Proposed changes
Fixes the launch parameter `map_server` of the `pathfinding_move_base.launch` file, which had an unknown value. Now `field2019.yaml`.

## Related issues
Closes #51.

## Necessary checks
- [x] Update package version
- [X] Run `catkin build`
  ~[ ] Write documentation~
  ~[ ] Create issues for future work~
- [X] Test on your machine
- [ ] Test on the robot
- [X] Put the PR on our Project board

