### PR TITLE
Move angle stuff to robot state

### DIFF
--- a/bitbots_localization/include/bitbots_localization/RobotState.h
+++ b/bitbots_localization/include/bitbots_localization/RobotState.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <Eigen/Core>
 #include <tf2/LinearMath/Quaternion.h>
+#include <bitbots_localization/tools.h>
 
 /**
 * @class CarState

--- a/bitbots_localization/package.xml
+++ b/bitbots_localization/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_localization</name>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <description>The bitbots_localization package.</description>
   <maintainer email="2hartfil@informatik.uni-hamburg.de">Judith Hartfill</maintainer>
   <license>MIT</license>

--- a/bitbots_localization/src/MotionModel.cpp
+++ b/bitbots_localization/src/MotionModel.cpp
@@ -44,11 +44,6 @@ void RobotMotionModel::drift(RobotState &state,
   state.setYPos(state.getYPos() + cartesian_with_offset_y);
   double theta = state.getTheta() + orientation_with_drift;
 
-  if (theta > M_PI) {
-    theta = -M_PI + (theta - M_PI);
-  } else if (theta < -M_PI) {
-    theta = M_PI + (theta + M_PI);
-  }
   state.setTheta(theta);
 
 }
@@ -58,11 +53,6 @@ void RobotMotionModel::diffuse(RobotState &state) const {
   state.setXPos(state.getXPos() + sample(diffuse_xStdDev_) * diffuse_multiplicator_);
   state.setYPos(state.getYPos() + sample(diffuse_yStdDev_) * diffuse_multiplicator_);
   double theta = state.getTheta() + sample(diffuse_tStdDev_) * diffuse_multiplicator_;
-  if (theta > M_PI) {
-    theta = -M_PI + (theta - M_PI);
-  } else if (theta < -M_PI) {
-    theta = M_PI + (theta + M_PI);
-  }
   state.setTheta(theta);
 }
 

--- a/bitbots_localization/src/RobotState.cpp
+++ b/bitbots_localization/src/RobotState.cpp
@@ -68,6 +68,7 @@ void RobotState::setYPos(double y) {
 }
 
 void RobotState::setTheta(double t) {
+  t = signedAngle(t);
   m_SinTheta = sin(t);
   m_CosTheta = cos(t);
 }


### PR DESCRIPTION
## Proposed changes
Until now the conv between the 2pi and +/- pi notation was done in many places before adding the angles to the robot state. Now this is done in the state itself.

## Related issues
#24 

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

