### PR TITLE
move base: disable obstacle inflation

### DIFF
--- a/bitbots_move_base/config/costmap_common_config.yaml
+++ b/bitbots_move_base/config/costmap_common_config.yaml
@@ -1,6 +1,6 @@
 obstacle_layer:
   enabled:                  true
-  voxel_decay:              1.0   # seconds if linear, e^n if exponential
+  voxel_decay:              5.0   # seconds if linear, e^n if exponential
   decay_model:              0     # 0=linear, 1=exponential, -1=persistent
   voxel_size:               0.05  # meters
   track_unknown_space:      true  # default space is known
@@ -21,7 +21,7 @@ obstacle_layer:
     topic: "/obstacles"
     marking: true
     clearing: false
-    min_obstacle_height: 0.0     # default 0, meters
+    min_obstacle_height: -0.1    # default 0, meters
     max_obstacle_height: 1.0     # default 3, meters
     expected_update_rate: 0.0    # default 0, if not updating at this rate at least, remove from buffer
     observation_persistence: 0.5 # default 0, use all measurements taken during now-value, 0=latest
@@ -31,6 +31,6 @@ obstacle_layer:
     clear_after_reading: true    # default false, clear the buffer after the layer gets readings from it
   
 inflation_layer:
-  enabled:              true
+  enabled:              false
   cost_scaling_factor:  10.0  # exponential rate at which the obstacle cost drops off (default: 10)
   inflation_radius:     0.2  # max. distance from an obstacle at which costs are incurred for planning paths.


### PR DESCRIPTION
## Proposed changes
This pull request disables obstacle inflation. This avoids the problem of not walking to the ball because the goal lies inside of the obstacle.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

