### PR TITLE
Particle outside field

### DIFF
--- a/bitbots_localization/cfg/localization.cfg
+++ b/bitbots_localization/cfg/localization.cfg
@@ -49,6 +49,8 @@ group_pf.add("particle_number", int_t, 0, "The amount of particles", None, min=1
 group_pf.add("resampling_interval", int_t, 0, "Number of filterupdates performed before resampling", None, min=0, max=10000)
 group_pf.add("min_weight", double_t, 0, "The minimal weight of a particle", None, min=0.0, max=1)
 group_pf.add("min_resampling_weight", double_t, 0, "The minimal weight of the best particle to resample", None, min=0.0, max=1)
+group_pf.add("out_of_field_weight_decrease", double_t, 0, "The amount the particle-weight is decreased by when the particle moves to far outside the field", None, min=0, max=1)
+group_pf.add("out_of_field_range", double_t, 0, "The distance a particle is allowed to be outside of the field", None, min=0, max=10)
 group_pf.add("percentage_best_particles", int_t, 0, "Percentage of best particles to generate pose from", None, min=0, max=100)
 group_pf.add("distance_factor", double_t, 0, "how much distant measurements get their weights reduced", None, min=0.0, max=1)
 group_pf.add("lines_factor", double_t, 0, "how much line measurements are contribute to the particle weight", None, min=0.0, max=1)

--- a/bitbots_localization/config/config.yaml
+++ b/bitbots_localization/config/config.yaml
@@ -56,6 +56,8 @@
 
   min_weight: 0.01
   min_resampling_weight: 0.1
+  out_of_field_weight_decrease: 0.01
+  out_of_field_range: 0.5  # in m
   percentage_best_particles: 50
 
   distance_factor : 0.5

--- a/bitbots_localization/docs/index.rst
+++ b/bitbots_localization/docs/index.rst
@@ -6,6 +6,11 @@ Description
 
 |description|
 
+Particle out of map decay
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The weight of pose_particles outside of the field is decreased because the robot should never expect to be there.
+
 .. toctree::
    :maxdepth: 2
 

--- a/bitbots_localization/src/ObservationModel.cpp
+++ b/bitbots_localization/src/ObservationModel.cpp
@@ -70,6 +70,16 @@ double RobotPoseObservationModel::measure(const RobotState &state) const {
     weight = min_weight_;
   }
 
+
+  // reduce weight if particle is too far outside of the field:
+  float range = config_.out_of_field_range;
+  if ( state.getXPos() > (config_.field_x + config_.field_padding)/2 + range
+    || state.getXPos() < -(config_.field_x + config_.field_padding)/2 - range
+    || state.getYPos() > (config_.field_y + config_.field_padding)/2 + range
+    || state.getYPos() < -(config_.field_y + config_.field_padding)/2 - range){
+    weight = weight - config_.out_of_field_weight_decrease;
+  }
+
   return weight; //exponential?
 }
 


### PR DESCRIPTION
## Proposed changes
The weight of pose_particles outside of the field is decreased because the robot should never expect to be there.
Merge only after #76.

## Related issues
fixes #22 

## Necessary checks
- [X] Run `catkin build`
- [x] Write documentation
~- [ ] Create issues for future work~
- [X] Test on your machine
- [X] Test on the robot (in Simulation)
- [x] Put the PR on our Project board

