### PR TITLE
FIx map origin in viz

### DIFF
--- a/bitbots_localization/config/fields/gazebo/map_server.yaml
+++ b/bitbots_localization/config/fields/gazebo/map_server.yaml
@@ -1,6 +1,6 @@
 image: lines.png
 resolution: 0.01
-origin: [-5.2, -3.7, 0.0]
+origin: [-5.5, -4., 0.0]
 occupied_thresh: 0.65
 free_thresh: 0.196
 negate: 0

--- a/bitbots_localization/config/fields/webots/map_server.yaml
+++ b/bitbots_localization/config/fields/webots/map_server.yaml
@@ -1,6 +1,6 @@
 image: lines.png
 resolution: 0.01
-origin: [-5.2, -3.7, 0.0]
+origin: [-5.5, -4., 0.0]
 occupied_thresh: 0.99
 free_thresh: 0.196
 negate: 0


### PR DESCRIPTION
Fixes the origin of the map in rviz for webots and gazebo.

Tested.

