### PR TITLE
localization: fix republishing of transforms in simulation

### DIFF
--- a/bitbots_localization/include/bitbots_localization/localization.h
+++ b/bitbots_localization/include/bitbots_localization/localization.h
@@ -206,6 +206,8 @@ class Localization {
   ros::Time last_stamp_lines_pc = ros::Time(0);
   ros::Time last_stamp_goals = ros::Time(0);
   ros::Time last_stamp_fb_points = ros::Time(0);
+  ros::Time localization_tf_last_published_time_ = ros::Time(0);
+  ros::Time map_odom_tf_last_published_time_ = ros::Time(0);
 
   std::string odom_frame_, base_footprint_frame_, map_frame_, publishing_frame_;
 

--- a/bitbots_localization/src/localization.cpp
+++ b/bitbots_localization/src/localization.cpp
@@ -441,7 +441,12 @@ void Localization::publish_transforms() {
     localization_transform.transform.rotation.y = q.y();
     localization_transform.transform.rotation.z = q.z();
     localization_transform.transform.rotation.w = q.w();
-    br.sendTransform(localization_transform);
+
+    if (localization_tf_last_published_time_ != localization_transform.header.stamp) {
+      // do not resend a transform for the same timestamp
+      localization_tf_last_published_time_ = localization_transform.header.stamp;
+      br.sendTransform(localization_transform);
+    }
 
     //publish odom localisation offset
     geometry_msgs::TransformStamped map_odom_transform;
@@ -458,7 +463,11 @@ void Localization::publish_transforms() {
 
     map_odom_transform.transform = tf2::toMsg(map_tf);
 
-    br.sendTransform(map_odom_transform);
+    if (map_odom_tf_last_published_time_ != map_odom_transform.header.stamp) {
+      // do not resend a transform for the same timestamp
+      map_odom_tf_last_published_time_ = map_odom_transform.header.stamp;
+      br.sendTransform(map_odom_transform);
+    }
   }
   catch (const tf2::TransformException &ex) {
     ROS_WARN("Odom not available, therefore odom offset can not be published: %s", ex.what());


### PR DESCRIPTION
## Proposed changes
In simulation, when the localization runs at a higher rate than the simulation clock, the tf currently gets republished with the same timestamp and a new transform. This is not supported by tf and spams the terminal with error messages on noetic.

## Related issues
This PR is the same as https://github.com/bit-bots/bitbots_motion/pull/195 and https://github.com/bit-bots/humanoid_base_footprint/pull/8.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

