### PR TITLE
Remove hacky fix

### DIFF
--- a/bitbots_localization/src/ObservationModel.cpp
+++ b/bitbots_localization/src/ObservationModel.cpp
@@ -119,14 +119,8 @@ void RobotPoseObservationModel::set_measurement_lines(hlm::LineInformationRelati
 
 
 void RobotPoseObservationModel::set_measurement_lines_pc(sm::PointCloud2 measurement){
-  int counter = 0;
   for (sm::PointCloud2ConstIterator<float> iter_xyz(measurement, "x"); iter_xyz != iter_xyz.end(); ++iter_xyz)
   {
-    counter ++;
-    if (counter % 10 != 0 )
-    {
-      continue;
-    }
     std::pair<double, double> linePolar = cartesianToPolar(iter_xyz[0], iter_xyz[1]);
     last_measurement_lines_.push_back(linePolar);
   }


### PR DESCRIPTION
## Proposed changes
Removes the hacky fix that drops most of the line points due to performance reasons.
This is possible because the sampling occurs in the transformer due to bit-bots/humanoid_league_misc#69 .

## Related issues
Waits for bit-bots/humanoid_league_misc#69

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

