### PR TITLE
Remove unneeded dependency

### DIFF
--- a/bitbots_local_planner/package.xml
+++ b/bitbots_local_planner/package.xml
@@ -15,7 +15,6 @@
     <depend>nav_core</depend>
     <depend>nav_msgs</depend>
     <depend>pluginlib</depend>
-    <build_depend>pcl_conversions</build_depend>
     <depend>roscpp</depend>
     <depend>tf2_geometry_msgs</depend>
 


### PR DESCRIPTION
## Proposed changes
`pcl_conversions` is not needed. The CI confirms that.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

