### PR TITLE
Split costmaps

### DIFF
--- a/bitbots_move_base/config/costmap_common_config.yaml
+++ b/bitbots_move_base/config/costmap_common_config.yaml
@@ -1,4 +1,4 @@
-obstacle_layer:
+robot_layer:
   enabled:                  true
   voxel_decay:              0.3   # seconds if linear, e^n if exponential
   decay_model:              0     # 0=linear, 1=exponential, -1=persistent

--- a/bitbots_move_base/config/costmap_common_config.yaml
+++ b/bitbots_move_base/config/costmap_common_config.yaml
@@ -33,7 +33,7 @@ robot_layer:
 
 ball_layer:
   enabled:                  true
-  voxel_decay:              1.0   # seconds if linear, e^n if exponential
+  voxel_decay:              0.3   # seconds if linear, e^n if exponential
   decay_model:              0     # 0=linear, 1=exponential, -1=persistent
   voxel_size:               0.05  # meters
   track_unknown_space:      true  # default space is known

--- a/bitbots_move_base/config/costmap_common_config.yaml
+++ b/bitbots_move_base/config/costmap_common_config.yaml
@@ -1,5 +1,38 @@
 obstacle_layer:
   enabled:                  true
+  voxel_decay:              0.3   # seconds if linear, e^n if exponential
+  decay_model:              0     # 0=linear, 1=exponential, -1=persistent
+  voxel_size:               0.05  # meters
+  track_unknown_space:      true  # default space is known
+  max_obstacle_height:      1.0   # meters
+  unknown_threshold:        15    # voxel height
+  mark_threshold:           0     # voxel height
+  update_footprint_enabled: true
+  combination_method:       1     # 1=max, 0=override
+  obstacle_range:           8.0   # meters
+  origin_z:                 0.0   # meters
+  publish_voxel_map:        false # default off
+  transform_tolerance:      0.2   # seconds
+  mapping_mode:             false # default off, saves map not for navigation
+  map_save_duration:        60.0  # default 60s, how often to autosave
+  observation_sources:      obstacles
+  obstacles:
+    data_type: PointCloud2
+    topic: "robot_obstacles"
+    marking: true
+    clearing: false
+    min_obstacle_height: -0.1    # default 0, meters
+    max_obstacle_height: 1.0     # default 3, meters
+    expected_update_rate: 0.0    # default 0, if not updating at this rate at least, remove from buffer
+    observation_persistence: 0.5 # default 0, use all measurements taken during now-value, 0=latest
+    inf_is_valid: false          # default false, for laser scans
+    voxel_filter: false          # default off, apply voxel filter to sensor, recommend on
+    voxel_min_points: 0          # default 0, minimum points per voxel for voxel filter
+    clear_after_reading: true    # default false, clear the buffer after the layer gets readings from it
+
+
+ball_layer:
+  enabled:                  true
   voxel_decay:              1.0   # seconds if linear, e^n if exponential
   decay_model:              0     # 0=linear, 1=exponential, -1=persistent
   voxel_size:               0.05  # meters
@@ -18,7 +51,7 @@ obstacle_layer:
   observation_sources:      obstacles
   obstacles:
     data_type: PointCloud2
-    topic: "obstacles"
+    topic: "ball_obstacles"
     marking: true
     clearing: false
     min_obstacle_height: -0.1    # default 0, meters

--- a/bitbots_move_base/config/global_costmap_config.yaml
+++ b/bitbots_move_base/config/global_costmap_config.yaml
@@ -1,10 +1,11 @@
 global_costmap:
   plugins:
-    - {name: obstacle_layer, type: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"}
+    - {name: robot_layer, type: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"}
+    - {name: ball_layer, type: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"}
     - {name: inflation_layer, type: "costmap_2d::InflationLayer"}
   # Set map origin to have the origin in the map center
-  origin_x: -7.5
-  origin_y: -7.5
+  origin_y: -4.0
+  origin_x: -5.5
   robot_base_frame: base_footprint
   global_frame: map
 
@@ -12,6 +13,6 @@ global_costmap:
   publish_frequency: 5.0
   transform_tolerance: 1.0
   rolling_window: false
-  width: 15.0
-  height: 15.0
+  width: 11.0
+  height: 8.0
   robot_radius: 0.2


### PR DESCRIPTION
## Proposed changes
*  Adapt global costmap size to field size + margin
* Split the costmap into one for the ball obstacle and one for the robots. 
* Maybe also split the robot obstacles by team in the futureNot

Note this needs a behavior fix before its merge