### PR TITLE
Re-depend `nav2_map_server` dependeny

### DIFF
--- a/bitbots_localization/package.xml
+++ b/bitbots_localization/package.xml
@@ -23,7 +23,7 @@
   <depend>bitbots_blackboard</depend>
   <depend>visualization_msgs</depend>
   <depend>builtin_interfaces</depend>
-  <!--depend>nav2_map_server</depend-->
+  <depend>nav2_map_server</depend>
   <depend>backward_ros</depend>
   <depend>dynamic_stack_decider</depend>
   <depend>python3-numpy</depend>


### PR DESCRIPTION
Re-depend `nav2_map_server` dependeny
Using packages.bit-bots.de this is available and needed here

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

